### PR TITLE
Bluetooth: Host: Fix use-after-free in bt_att_sent on disconnect

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3409,6 +3409,18 @@ static void bt_att_released(struct bt_l2cap_chan *ch)
 
 	LOG_DBG("chan %p", chan);
 
+	/* Drop any pending/in-flight ATT TX metadata still referencing this
+	 * channel, so the deferred att_on_sent_cb()/bt_att_sent() work cannot
+	 * dereference the channel after it is freed here. Bluetooth uses a
+	 * cooperative system workqueue, so this runs serialized with
+	 * att_tx_destroy_work_handler() and aligned pointer writes are atomic.
+	 */
+	ARRAY_FOR_EACH(tx_meta_data_storage, i) {
+		if (tx_meta_data_storage[i].att_chan == chan) {
+			tx_meta_data_storage[i].att_chan = NULL;
+		}
+	}
+
 	k_mem_slab_free(&chan_slab, (void *)chan);
 }
 


### PR DESCRIPTION
Backport of the merged upstream fix for the ATT use-after-free that crashes on disconnect (SOFTWARE-10962).

### Problem
On disconnect the `bt_att` / `bt_att_chan` are freed (`att_chan_detach()`/`att_reset()`, then `bt_att_released()`) while a deferred unenhanced-ATT "sent" callback is still queued on the system workqueue. The destroy work runs `att_on_sent_cb()` -> `bt_att_sent()`, dereferences the freed channel and faults — observed as `ASSERTION FAIL [z_spin_lock_valid(l)]` / "Invalid spinlock" in `process_queue()` -> `k_queue_get()` on `sysworkq`.

### Fix
Cherry-pick of upstream commit `dfdea9bad8d` (zephyrproject-rtos/zephyr#110416, merged 2026-06-05). In `bt_att_released()`, before the channel slab is freed, null `att_chan` for every `tx_meta_data_storage[]` entry pointing at it, so the existing guard in `att_on_sent_cb()` drops the deferred callback instead of touching freed memory. No lock needed (cooperative system workqueue).

`pre_rel_26.06.0` predates that upstream commit, so it does not have the fix yet.

### Notes
- Clean cherry-pick, no local rework; author preserved (Hayden Ball).
- Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/110416
- The `reason 0x28` (Instant Passed) disconnect that triggers this teardown and fails onboarding is a separate issue, tracked under SOFTWARE-10962.
